### PR TITLE
Add layout to reserva list

### DIFF
--- a/app/Views/reserva/listReserva.php
+++ b/app/Views/reserva/listReserva.php
@@ -1,6 +1,9 @@
 <?php
+$this->extend('layouts/main_layout');
 $session = session();
 ?>
+
+<?= $this->section('content'); ?>
 
 <div class="container-fluid">
     <div class="row">
@@ -134,3 +137,5 @@ $session = session();
         }
     });
 </script>
+
+<?= $this->endSection(); ?>


### PR DESCRIPTION
## Summary
- use `main_layout` for the reserva listing so it has the navigation menu

## Testing
- `vendor/bin/phpunit` *(fails: Unable to connect to the database)*

------
https://chatgpt.com/codex/tasks/task_e_6852b10888b0832a8fc03a18b73f36b5