### PR TITLE
Fix Reserva controller db check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ to your `app` folder. The affected files can be copied or merged from
 Copy `env` to `.env` and tailor for your app, specifically the baseURL
 and any database settings.
 
+The application reads database credentials from the following environment variables:
+
+- `database.default.hostname`
+- `database.default.username`
+- `database.default.password`
+- `database.default.database`
+
+If these are not set, the defaults from `app/Config/Database.php` will be used.
+
 ## Important Change with index.php
 
 `index.php` is no longer in the root of the project! It has been moved inside the *public* folder,

--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -193,6 +193,11 @@ class Database extends Config
     {
         parent::__construct();
 
+        $this->default['hostname'] = getenv('database.default.hostname') ?: $this->default['hostname'];
+        $this->default['username'] = getenv('database.default.username') ?: $this->default['username'];
+        $this->default['password'] = getenv('database.default.password') ?: $this->default['password'];
+        $this->default['database'] = getenv('database.default.database') ?: $this->default['database'];
+
         // Ensure that we always set the database group to 'tests' if
         // we are currently running an automated test suite, so that
         // we don't overwrite live data on accident.

--- a/app/Controllers/Reserva.php
+++ b/app/Controllers/Reserva.php
@@ -15,22 +15,10 @@ class Reserva extends Controller
     public function index()
     {
         $session = session();
-        $db = \Config\Database::connect();
-        if ($db->connID) {
-            log_message('info', 'Conexión a la base de datos exitosa');
-            $session->setFlashdata([
-                'success'   => 'Conexión a la base de datos exitosa',
-                'toastType' => 'success',
-            ]);
-        } else {
-            log_message('error', 'No se pudo conectar a la base de datos');
-            $session->setFlashdata([
-                'error'     => 'No se pudo conectar a la base de datos',
-                'toastType' => 'error',
-            ]);
-        }
 
         try {
+            $db = \Config\Database::connect();
+            $db->initialize();
             $model = new ReservaModel();
             $reservas = $model->findAll();
             log_message('info', 'Reservas obtenidas: ' . count($reservas));
@@ -42,7 +30,7 @@ class Reserva extends Controller
         } catch (\Exception $e) {
             log_message('error', 'Error al obtener las reservas: ' . $e->getMessage());
             $session->setFlashdata([
-                'error'     => 'Error al obtener las reservas',
+                'error'     => 'No se pudo conectar a la base de datos',
                 'toastType' => 'error',
             ]);
             return view('reserva/listReserva', ['reservas' => []]);


### PR DESCRIPTION
## Summary
- correct misleading DB connection check
- make DB credentials overridable via env vars
- document new env vars for DB settings

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6852b5cc9118832abf06c7a6abaadeb8