### PR TITLE
Improve database error debugging

### DIFF
--- a/app/Controllers/Reserva.php
+++ b/app/Controllers/Reserva.php
@@ -27,11 +27,12 @@ class Reserva extends Controller
                 'toastType' => 'success',
             ]);
             return view('reserva/listReserva', ['reservas' => $reservas]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             log_message('error', 'Error al obtener las reservas: ' . $e->getMessage());
             $session->setFlashdata([
-                'error'     => 'No se pudo conectar a la base de datos',
-                'toastType' => 'error',
+                'error'      => 'No se pudo conectar a la base de datos',
+                'toastType'  => 'error',
+                'debugError' => $e->getMessage(),
             ]);
             return view('reserva/listReserva', ['reservas' => []]);
         }

--- a/app/Views/reserva/listReserva.php
+++ b/app/Views/reserva/listReserva.php
@@ -135,6 +135,10 @@ $session = session();
         } else {
             console.error('No se encontró la tabla');
         }
+
+        <?php if (session()->has('debugError')): ?>
+        console.error('DB Error:', <?= json_encode(session('debugError')) ?>);
+        <?php endif; ?>
     });
 </script>
 


### PR DESCRIPTION
## Summary
- capture exception details in Reserva controller
- print any DB error message to the browser console

## Testing
- `composer install` *(fails: composer not found)*


------
https://chatgpt.com/codex/tasks/task_e_68532864b32c832a9a5d9849613a654d