### PR TITLE
Fix flash message retrieval and schema config

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -30,6 +30,7 @@ class Database extends Config
         'username'     => 'postgres',
         'password'     => 'Root',
         'database'     => 'ciya25',
+        'schema'       => 'laboratorios',
         'DBDriver'     => 'Postgre',
         'DBPrefix'     => '',
         'pConnect'     => false,

--- a/app/Controllers/Reserva.php
+++ b/app/Controllers/Reserva.php
@@ -27,11 +27,12 @@ class Reserva extends Controller
                 'toastType' => 'success',
             ]);
             return view('reserva/listReserva', ['reservas' => $reservas]);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             log_message('error', 'Error al obtener las reservas: ' . $e->getMessage());
             $session->setFlashdata([
-                'error'     => 'No se pudo conectar a la base de datos',
-                'toastType' => 'error',
+                'error'      => 'No se pudo conectar a la base de datos',
+                'toastType'  => 'error',
+                'debugError' => $e->getMessage(),
             ]);
             return view('reserva/listReserva', ['reservas' => []]);
         }

--- a/app/Models/ReservaModel.php
+++ b/app/Models/ReservaModel.php
@@ -6,7 +6,7 @@ use CodeIgniter\Model;
 
 class ReservaModel extends Model
 {
-    protected $table = 'laboratorios.reserva';
+    protected $table = 'reserva';
     protected $primaryKey = 'id_reserva';
     protected $allowedFields = [
         'fk_id_lab',

--- a/app/Views/layouts/main_layout.php
+++ b/app/Views/layouts/main_layout.php
@@ -92,20 +92,20 @@
     <script>
         // Manejar mensajes de sesión
         $(document).ready(function() {
-            <?php if (session()->has('success')): ?>
+            <?php if ($msg = session()->getFlashdata('success')): ?>
                 iziToast.success({
                     title: 'Éxito',
-                    message: "<?= session('success') ?>",
+                    message: "<?= $msg ?>",
                     position: 'topRight',
                     timeout: 3000,
                     progressBar: true
                 });
             <?php endif; ?>
 
-            <?php if (session()->has('error')): ?>
+            <?php if ($err = session()->getFlashdata('error')): ?>
                 iziToast.error({
                     title: 'Error',
-                    message: "<?= session('error') ?>",
+                    message: "<?= $err ?>",
                     position: 'topRight',
                     timeout: 3000,
                     progressBar: true
@@ -169,9 +169,14 @@
 
     <script>
         $(document).ready(function() {
-            <?php if (session()->has('toastType')): ?>
-                const message = session('success') || session('error');
-                const type = session('toastType');
+            <?php
+                $toastType = session()->getFlashdata('toastType');
+                $successMsg = session()->getFlashdata('success');
+                $errorMsg   = session()->getFlashdata('error');
+                if ($toastType):
+            ?>
+                const message = "<?= $successMsg ?? $errorMsg ?>";
+                const type = "<?= $toastType ?>";
                 
                 switch(type) {
                     case 'success':

--- a/app/Views/reserva/listReserva.php
+++ b/app/Views/reserva/listReserva.php
@@ -27,15 +27,15 @@ $session = session();
             </div>
 
             <!-- Mensajes de sesión -->
-            <?php if (session()->has('error')): ?>
+            <?php if ($error = session()->getFlashdata('error')): ?>
                 <div class="alert alert-danger">
-                    <?= session('error') ?>
+                    <?= $error ?>
                 </div>
             <?php endif; ?>
-            
-            <?php if (session()->has('success')): ?>
+
+            <?php if ($success = session()->getFlashdata('success')): ?>
                 <div class="alert alert-success">
-                    <?= session('success') ?>
+                    <?= $success ?>
                 </div>
             <?php endif; ?>
 
@@ -135,6 +135,10 @@ $session = session();
         } else {
             console.error('No se encontró la tabla');
         }
+
+        <?php if ($debug = session()->getFlashdata('debugError')): ?>
+        console.error('DB Error:', <?= json_encode($debug) ?>);
+        <?php endif; ?>
     });
 </script>
 


### PR DESCRIPTION
## Summary
- configure PostgreSQL schema in database connection
- adjust Reserva model table name
- use getFlashdata in layout and reservations view
- log database error to browser console reliably

## Testing
- `composer install`
- `vendor/bin/phpunit --testsuite unit` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68532864b32c832a9a5d9849613a654d