### PR TITLE
Enable Reserva forms with CSRF

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -31,4 +31,8 @@ $routes->delete('docente/delete/(:num)', 'Docente::delete/$1');
 
 // Rutas para Reservas
 $routes->get('reserva', 'Reserva::index');
+$routes->get('reserva/create', 'Reserva::create');
+$routes->post('reserva/store', 'Reserva::store');
+$routes->get('reserva/edit/(:num)', 'Reserva::edit/$1');
+$routes->post('reserva/update/(:num)', 'Reserva::update/$1');
 $routes->get('reserva/delete/(:num)', 'Reserva::delete/$1');

--- a/app/Controllers/Reserva.php
+++ b/app/Controllers/Reserva.php
@@ -3,6 +3,8 @@
 namespace App\Controllers;
 
 use App\Models\ReservaModel;
+use App\Models\LaboratorioModel;
+use App\Models\DocenteModel;
 use CodeIgniter\Controller;
 
 class Reserva extends Controller
@@ -11,6 +13,7 @@ class Reserva extends Controller
 
     public function __construct()
     {
+        helper('session');
         $this->model = new ReservaModel();
     }
 
@@ -21,12 +24,97 @@ class Reserva extends Controller
                 'reservas' => $this->model->getAllReservas(),
                 'title' => 'Listado de Reservas'
             ];
-            
+
             return view('reserva/listReserva', $data);
         } catch (\Exception $e) {
             return view('errors/html/error_500', [
                 'message' => 'Error al cargar las reservas: ' . $e->getMessage()
             ]);
+        }
+    }
+
+    public function create()
+    {
+        $laboratorioModel = new LaboratorioModel();
+        $docenteModel     = new DocenteModel();
+
+        $data = [
+            'laboratorios' => $laboratorioModel->findAll(),
+            'docentes'     => $docenteModel->findAll(),
+        ];
+
+        return view('reserva/addReserva', $data);
+    }
+
+    public function store()
+    {
+        try {
+            $data = [
+                'fk_id_lab'          => $this->request->getPost('fk_id_lab'),
+                'fk_id_doc'          => $this->request->getPost('fk_id_doc'),
+                'fecha_reserva'      => $this->request->getPost('fecha_reserva'),
+                'hora_inicio_reserva'=> $this->request->getPost('hora_inicio_reserva'),
+                'hora_fin_reserva'   => $this->request->getPost('hora_fin_reserva'),
+                'estado_reserva'     => $this->request->getPost('estado_reserva'),
+                'motivo_reserva'     => $this->request->getPost('motivo_reserva'),
+            ];
+
+            if ($this->model->save($data)) {
+                return redirect()->to('/reserva')->with('success', 'Reserva agregada correctamente');
+            }
+
+            return redirect()->back()
+                ->with('error', 'Hubo un problema al agregar la reserva')
+                ->withInput()
+                ->with('errors', $this->model->errors());
+        } catch (\Exception $e) {
+            return redirect()->back()->with('error', 'Error inesperado: ' . $e->getMessage())->withInput();
+        }
+    }
+
+    public function edit($id)
+    {
+        $reserva = $this->model->find($id);
+
+        if (!$reserva) {
+            return redirect()->back()->with('error', 'Reserva no encontrada');
+        }
+
+        $laboratorioModel = new LaboratorioModel();
+        $docenteModel     = new DocenteModel();
+
+        $data = [
+            'reserva'      => $reserva,
+            'laboratorios' => $laboratorioModel->findAll(),
+            'docentes'     => $docenteModel->findAll(),
+        ];
+
+        return view('reserva/editReserva', $data);
+    }
+
+    public function update($id)
+    {
+        try {
+            $data = [
+                'fk_id_lab'          => $this->request->getPost('fk_id_lab'),
+                'fk_id_doc'          => $this->request->getPost('fk_id_doc'),
+                'fecha_reserva'      => $this->request->getPost('fecha_reserva'),
+                'hora_inicio_reserva'=> $this->request->getPost('hora_inicio_reserva'),
+                'hora_fin_reserva'   => $this->request->getPost('hora_fin_reserva'),
+                'estado_reserva'     => $this->request->getPost('estado_reserva'),
+                'motivo_reserva'     => $this->request->getPost('motivo_reserva'),
+            ];
+
+            if ($this->model->update($id, $data)) {
+                return redirect()->to('/reserva')->with('success', 'Reserva actualizada correctamente');
+            }
+
+            return redirect()->back()
+                ->with('error', 'Hubo un problema al actualizar la reserva')
+                ->withInput()
+                ->with('errors', $this->model->errors());
+        } catch (\Exception $e) {
+            return redirect()->back()->with('error', 'Error inesperado: ' . $e->getMessage())->withInput();
         }
     }
 

--- a/app/Views/reserva/addReserva.php
+++ b/app/Views/reserva/addReserva.php
@@ -17,7 +17,8 @@
                 </div>
             <?php endif; ?>
 
-            <form action="/reserva/store" method="post">
+            <form action="<?= site_url('reserva/store') ?>" method="post">
+                <?= csrf_field() ?>
                 <div class="form-group">
                     <label for="fk_id_lab">Laboratorio</label>
                     <select name="fk_id_lab" id="fk_id_lab" class="form-control" required>

--- a/app/Views/reserva/editReserva.php
+++ b/app/Views/reserva/editReserva.php
@@ -17,7 +17,8 @@
                 </div>
             <?php endif; ?>
 
-            <form action="/reserva/update/<?= $reserva['id_reserva'] ?>" method="post">
+            <form action="<?= site_url('reserva/update/' . $reserva['id_reserva']) ?>" method="post">
+                <?= csrf_field() ?>
                 <div class="form-group">
                     <label for="fk_id_lab">Laboratorio</label>
                     <select name="fk_id_lab" id="fk_id_lab" class="form-control" required>


### PR DESCRIPTION
## Summary
- add CSRF and use `site_url()` in Reserva create and edit forms

## Testing
- `php -l app/Views/reserva/addReserva.php` *(fails: php not installed)*
- `php -l app/Views/reserva/editReserva.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68536de309a0832a87b5beef932a80a3